### PR TITLE
Fix deprecation warning

### DIFF
--- a/homeassistant/components/climate/intesishome.py
+++ b/homeassistant/components/climate/intesishome.py
@@ -274,7 +274,7 @@ class IntesisAC(ClimateDevice):
     def update_callback(self):
         """Called when data is received by pyIntesishome."""
         _LOGGER.debug("IntesisHome sent a status update.")
-        self.hass.async_add_job(self.update_ha_state, True)
+        self.hass.async_add_job(self.schedule_update_ha_state, True)
 
     @property
     def min_temp(self):


### PR DESCRIPTION
## Description:

Fixes deprecation warning: `WARNING (Thread-1) [homeassistant.helpers.entity] 'update_ha_state' is deprecated. Use 'schedule_update_ha_state' instead.`

Excellent work on intesishome climate module! Really happy with it and using it every day!

Keep up the pull request though ^-^


